### PR TITLE
Fix and modify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 DOCUMENT = content
 
 build: $(DOCUMENT).tex

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ build: $(DOCUMENT).tex
 	pdflatex -halt-on-error -shell-escape $(DOCUMENT).tex > /dev/null 2>&1
 
 clean:
-	rm -rf $(DOCUMENT).{aux,log,nav,out,snm,toc,vrb} _minted*
+	$(RM) $(DOCUMENT).{aux,log,nav,out,snm,toc,vrb} -r _minted*


### PR DESCRIPTION
Because the default shell on Ubuntu is probably `/bin/sh`, which does not perform shell expansion, the command `make clean` does not work. Therefore, I changed the default shell to `/bin/bash`.

Second, I change the `clean` target to use the implicit $(RM) variable of `make`.